### PR TITLE
Release openzot-tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 
 configs/zot.yaml
 .env
+
+# Local development only: redirects the pinned go-sdk to the monorepo checkout.
+go.work
+go.work.sum

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,10 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
-	github.com/chatbotkit/go-sdk v0.0.0
+	// The published ChatBotKit Go SDK. Pinned to a release for reproducible CI /
+	// production builds. For local development against the monorepo checkout, a
+	// gitignored go.work redirects this to ../../../sdks/go.
+	github.com/chatbotkit/go-sdk v0.1.1
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-isatty v0.0.20
 	gopkg.in/yaml.v3 v3.0.1
@@ -35,5 +38,3 @@ require (
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )
-
-replace github.com/chatbotkit/go-sdk => ../../../sdks/go

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMx
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
+github.com/chatbotkit/go-sdk v0.1.1 h1:luefnGxlVH5zjGskwt8aYRxOIusnRhnl2o9qaM7j088=
+github.com/chatbotkit/go-sdk v0.1.1/go.mod h1:u9QxNKUqhls4OOPMuVE0i/Q4wTJMgBARKw+CcQIeg00=
 github.com/clipperhouse/displaywidth v0.9.0 h1:Qb4KOhYwRiN3viMv1v/3cTBlz3AcAZX3+y9OLhMtAtA=
 github.com/clipperhouse/displaywidth v0.9.0/go.mod h1:aCAAqTlh4GIVkhQnJpbL0T/WfcrJXHcj8C0yjYcjOZA=
 github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `incubator/openzot/tool` on branch `next` → `main`.