### PR TITLE
Release openzot-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,49 @@ front-end. It launches the agent in a goroutine and renders the event stream
 (`ToolCallStart`, `ToolCallEnd`, `Iteration`, token narration, `AgentExit`, …)
 into a scrollable, read-only viewport. The UI deliberately has no text input.
 
+## Why CBK?
+
+CBK.AI is a capable cloud harness: the agentic loop — model calls, tool
+orchestration, planning, iteration — runs server-side. That pushes the heavy
+lifting off the executable, so the local runtime stays minimal. The binary is
+small, and the code that remains here is tiny: load some config, wire the SDK's
+tools, and render events. That makes zot easy to read, reason about, and extend.
+
+The backend is an implementation detail behind the agent package. We may add
+other backends in the future; for now ChatBotKit keeps things lightweight.
+
 ## Prerequisites
 
 - Go 1.24+
-- A ChatBotKit API key — get one at [chatbotkit.com](https://chatbotkit.com)
+- A ChatBotKit API token (see below)
+
+## API token
+
+zot needs its own ChatBotKit API token to run. **Mint a new one for the tool** —
+don't reuse a token from elsewhere.
+
+We **recommend** creating a scoped token at
+[chatbotkit.com/apps/code](https://chatbotkit.com/apps/code). This issues a token
+limited to coding-harness operations only, so it **cannot** reach the rest of
+your account.
+
+Provide the token either way:
+
+**1. Environment variable (preferred)** — export `CHATBOTKIT_API_SECRET`, or put
+it in a `.env` file in the working directory:
+
+```bash
+export CHATBOTKIT_API_SECRET="cbk_…"
+```
+
+**2. Config file** — set `api_secret` under the `chatbotkit` section of your
+config file (`~/.config/zot/config.yaml`, or the path given to `--config`):
+
+```yaml
+# ~/.config/zot/config.yaml
+chatbotkit:
+  api_secret: 'cbk_…'
+```
 
 ## Setup
 
@@ -90,6 +129,7 @@ export CHATBOTKIT_API_SECRET="your-api-key"   # or use .env
 | `--task-file`      | _(none)_                    | Read the task from a file instead of the command line      |
 | `--diff`           | `false`                     | Show a syntax-highlighted diff panel under each edit/write |
 | `--plain`          | `false`                     | Stream unstyled output (auto-enabled when not a TTY)       |
+| `--feature`        | _(none)_                    | Enable a feature by name (repeatable): `web`, `chunking`   |
 | `--config`         | `~/.config/zot/config.yaml` | Path to a config file (optional)                           |
 | `--version`        |                             | Print the version and exit                                 |
 
@@ -127,6 +167,30 @@ alt-screen UI that would garble or fail. Force it in a terminal with `--plain`
 zot --plain "tidy go.mod" | tee run.log
 ```
 
+### Features
+
+Enable ChatBotKit conversation features for the run — each a name/options pair.
+Currently exposed: **`web`** (live web `search`/`fetch`) and **`chunking`**. Set
+them with repeated `--feature` flags:
+
+```bash
+zot --feature web --feature chunking "research the latest go release and summarise it"
+```
+
+…or in the config file, where you can also pass per-feature options:
+
+```yaml
+features:
+  - name: web
+    options:
+      search: true
+      fetch: true
+  - name: chunking
+```
+
+`--feature` flags replace the configured list when given. (The list isn't
+settable via a single env var — use the config file for options.)
+
 ## Configuration
 
 Configuration is layered: built-in defaults < config file < `ZOT_*` environment
@@ -152,6 +216,29 @@ Because the agent is autonomous, the only keys are for viewing:
 | `PgUp`/`PgDn` | page the log       |
 | `g` / `G`     | jump to top/bottom |
 | `q`           | quit               |
+
+## Project context (`AGENT.md` & skills)
+
+On startup zot folds in context from two places — the **config directory**
+(`~/.config/zot/`, global) and the **working directory** (`--dir`, per-project):
+
+- **`AGENT.md`** — at the **root** of either directory; its contents are
+  appended to the agent's backstory (config first, then project). Use it for
+  conventions the agent should always follow.
+- **skills** — each `<name>/SKILL.md` (with `name` / `description` YAML front
+  matter) is loaded via the SDK and passed to the agent as a `skills` feature;
+  the agent reads a skill's full file on demand when it's relevant. Both
+  **`.skills/`** (typical at a project root) and **`skills/`** are searched.
+
+```
+~/.config/zot/          ./ (your project, --dir)
+├── AGENT.md            ├── AGENT.md
+└── skills/             └── .skills/
+    └── greet/              └── deploy/
+        └── SKILL.md            └── SKILL.md
+```
+
+Everything here is optional — missing files and directories are ignored.
 
 ## ⚠️ Safety
 

--- a/README.md
+++ b/README.md
@@ -8,31 +8,7 @@ problem entirely on
 its own — reading files, editing them, and running shell commands — while the
 terminal streams a live, **read-only** view of every step it takes.
 
-```
-✦ zot  ⠹ working   add a /health endpoint and a test for it
-model kimi-k2.7-code  ·  dir ~/scratch/api  ·  iter 3  ·  tools 9  ·  edits 2  ·  elapsed 00:41
-
-── iteration 1 ───────────────────────────────────────────────────────────────
-  plan  break the task into endpoint + test, then verify
-    1. read the existing router
-    2. add the /health handler
-    3. write a test and run it
-  read   server.go
-    ✓ 84 lines
-── iteration 2 ───────────────────────────────────────────────────────────────
-  edit   server.go
-    ✓ applied
-  write  server_test.go
-    ✓ saved
-  exec   go test ./...
-    │ ok  	example/api	0.012s
-    ✓ done
-  ▸ all steps complete, tests green
-
-✓ done  added /health endpoint and a passing test
-
-↑/↓ scroll  g/G top/bottom  q quit
-```
+<img width="1504" height="1080" alt="Area" src="https://github.com/user-attachments/assets/d12de01c-f13e-451c-93a3-d025b5b39dc6" />
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ the activity log — scroll back to review any change the agent made:
 ```
   edit   internal/server/server.go
  ╭───────────────────────────────────────────────────────────╮
- │ internal/server/server.go  +2 -1                           │
- │   func (s *Server) routes() {                              │
- │ -   mux.HandleFunc("/", s.handleIndex)                     │
- │ +   mux.HandleFunc("/", s.handleIndex)                     │
+ │ internal/server/server.go  +2 -1                          │
+ │   func (s *Server) routes() {                             │
+ │ -   mux.HandleFunc("/", s.handleIndex)                    │
+ │ +   mux.HandleFunc("/", s.handleIndex)                    │
  │ +   mux.HandleFunc("/health", s.handleHealth)             │
- │   }                                                        │
+ │   }                                                       │
  ╰───────────────────────────────────────────────────────────╯
 ```
 

--- a/cmd/zot/main.go
+++ b/cmd/zot/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -47,6 +48,8 @@ func run() error {
 	taskFile := flag.String("task-file", "", "read the task from this file instead of the command line")
 	diffFlag := flag.Bool("diff", false, "show a syntax-highlighted diff panel under each edit/write")
 	plainFlag := flag.Bool("plain", false, "stream unstyled output instead of the full-screen UI (auto-enabled when not a TTY)")
+	var featureFlags stringSlice
+	flag.Var(&featureFlags, "feature", "enable a ChatBotKit feature by name (repeatable): "+strings.Join(config.AllowedFeatures, ", "))
 	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Usage = usage
 	flag.Parse()
@@ -74,6 +77,14 @@ func run() error {
 	if *maxIter > 0 {
 		cfg.Agent.MaxIterations = *maxIter
 	}
+	// --feature (repeatable) replaces the configured features when given.
+	if len(featureFlags) > 0 {
+		features := make([]config.Feature, 0, len(featureFlags))
+		for _, name := range featureFlags {
+			features = append(features, config.Feature{Name: name})
+		}
+		cfg.Features = features
+	}
 	flag.Visit(func(f *flag.Flag) {
 		switch f.Name {
 		case "diff":
@@ -87,11 +98,26 @@ func run() error {
 		return err
 	}
 
+	// Resolve the config directory (source of any global AGENT.md / skills) while
+	// the original working directory is still current, so a relative --config
+	// resolves correctly before the chdir below.
+	configDir := config.ConfigDir(*configPath)
+	if abs, err := filepath.Abs(configDir); err == nil {
+		configDir = abs
+	}
+
 	// Sandbox the coding tools to --dir before the agent starts. DefaultTools()
 	// operates relative to the process working directory, so a chdir is the
 	// simplest way to scope the agent to the target project.
 	if err := os.Chdir(*dir); err != nil {
 		return fmt.Errorf("cannot enter --dir %q: %w", *dir, err)
+	}
+
+	// Fold in AGENT.md and skills from the config directory, then the working
+	// directory (project-level context wins / appends last).
+	workDir, _ := os.Getwd()
+	if err := zot.LoadProjectContext(&cfg, configDir, workDir); err != nil {
+		return err
 	}
 
 	return zot.Run(context.Background(), cfg, task)
@@ -133,4 +159,14 @@ Examples:
 
 Flags:`)
 	flag.PrintDefaults()
+}
+
+// stringSlice is a flag.Value that accumulates a repeatable string flag.
+type stringSlice []string
+
+func (s *stringSlice) String() string { return strings.Join(*s, ",") }
+
+func (s *stringSlice) Set(v string) error {
+	*s = append(*s, strings.TrimSpace(v))
+	return nil
 }

--- a/configs/zot.example.yaml
+++ b/configs/zot.example.yaml
@@ -42,3 +42,13 @@ ui:
   # Force the unstyled streaming renderer instead of the full-screen UI. Plain
   # mode is also selected automatically when stdout is not a terminal.
   plain: false
+
+# ChatBotKit conversation features to enable, as a list of name/options pairs.
+# Currently exposed: web, chunking. (Override from the CLI with repeated
+# --feature flags, e.g. --feature web --feature chunking.)
+features:
+  # - name: web
+  #   options:
+  #     search: true
+  #     fetch: true
+  # - name: chunking

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,28 @@ type Config struct {
 	Agent      Agent      `yaml:"agent"`
 	ChatBotKit ChatBotKit `yaml:"chatbotkit"`
 	UI         UI         `yaml:"ui"`
+	// Features are ChatBotKit conversation features to enable for the run, each a
+	// name/options pair passed through to the agent.
+	Features []Feature `yaml:"features"`
+}
+
+// Feature is a ChatBotKit conversation feature enabled for the run: a name plus
+// optional, feature-specific options.
+type Feature struct {
+	Name    string                 `yaml:"name"`
+	Options map[string]interface{} `yaml:"options"`
+}
+
+// AllowedFeatures is the set of feature names zot currently exposes.
+var AllowedFeatures = []string{"web", "chunking"}
+
+func featureAllowed(name string) bool {
+	for _, a := range AllowedFeatures {
+		if a == name {
+			return true
+		}
+	}
+	return false
 }
 
 // UI holds presentation options for the read-only viewer.
@@ -104,6 +126,14 @@ func (c Config) Validate() error {
 	}
 	if c.Agent.MaxIterations <= 0 {
 		return fmt.Errorf("agent.max_iterations must be a positive number")
+	}
+	for _, f := range c.Features {
+		if strings.TrimSpace(f.Name) == "" {
+			return fmt.Errorf("features: each feature needs a name")
+		}
+		if !featureAllowed(f.Name) {
+			return fmt.Errorf("features: unknown feature %q (allowed: %s)", f.Name, strings.Join(AllowedFeatures, ", "))
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,3 +55,20 @@ func TestValidate(t *testing.T) {
 		t.Error("expected an error for non-positive max_iterations")
 	}
 }
+
+func TestValidateFeatures(t *testing.T) {
+	base := Agent{Model: "m", MaxIterations: 1}
+
+	ok := Config{Agent: base, Features: []Feature{{Name: "web"}, {Name: "chunking"}}}
+	if err := ok.Validate(); err != nil {
+		t.Errorf("unexpected error for allowed features: %v", err)
+	}
+
+	if err := (Config{Agent: base, Features: []Feature{{Name: "bash"}}}).Validate(); err == nil {
+		t.Error("expected an error for a feature outside the allow-list")
+	}
+
+	if err := (Config{Agent: base, Features: []Feature{{Name: ""}}}).Validate(); err == nil {
+		t.Error("expected an error for a feature with no name")
+	}
+}

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -41,6 +41,11 @@ func applyEnvStruct(v reflect.Value, prefix string) error {
 			}
 			continue
 		}
+		// Slices and maps (e.g. features) are not settable via a scalar env var;
+		// configure them in the file. Skip rather than error.
+		if fv.Kind() == reflect.Slice || fv.Kind() == reflect.Map {
+			continue
+		}
 		raw, ok := os.LookupEnv(name)
 		if !ok {
 			continue

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -21,6 +21,15 @@ func DefaultConfigPath() string {
 	return filepath.Join(xdgConfigHome(), "zot", "config.yaml")
 }
 
+// ConfigDir returns the directory that holds the config file — and any global
+// AGENT.md / skills — for the given --config value ("" uses the default path).
+func ConfigDir(path string) string {
+	if strings.TrimSpace(path) == "" {
+		path = DefaultConfigPath()
+	}
+	return filepath.Dir(path)
+}
+
 func xdgConfigHome() string {
 	if dir := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); dir != "" {
 		return dir

--- a/zot.go
+++ b/zot.go
@@ -11,18 +11,37 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/chatbotkit/go-sdk/agent"
 	"github.com/chatbotkit/go-sdk/sdk"
+	"github.com/chatbotkit/go-sdk/types"
 
 	"github.com/chatbotkit/zot/internal/config"
 	"github.com/chatbotkit/zot/internal/tui"
 	"github.com/chatbotkit/zot/internal/version"
 )
 
+// Names zot looks for under each context directory.
+const (
+	agentFile      = "AGENT.md"
+	skillsFeature  = "skills"
+	projectContext = "# Project context"
+)
+
+// skillSubdirs are the folder names searched for skills under each context
+// directory. Both the hidden ".skills" (typical at a project root) and the plain
+// "skills" (e.g. directly in the config directory) are accepted.
+var skillSubdirs = []string{".skills", "skills"}
+
 // Config is the fully-resolved zot configuration. Load it with Load; its
 // Validate method enforces the same checks the standalone binary runs.
 type Config = config.Config
+
+// Feature is a ChatBotKit conversation feature (a name/options pair) enabled for
+// the run.
+type Feature = config.Feature
 
 // DefaultBackstory is the system instruction handed to the agent when the
 // configuration does not override it. It establishes the fully-autonomous,
@@ -50,6 +69,61 @@ func Load(path string) (Config, error) { return config.Load(path) }
 
 // DefaultConfigPath is the default config file location.
 func DefaultConfigPath() string { return config.DefaultConfigPath() }
+
+// LoadProjectContext augments cfg with on-disk context discovered under the
+// given directories, searched in order (typically the config directory first,
+// then the working directory):
+//
+//   - <dir>/AGENT.md  — appended to the agent backstory
+//   - <dir>/skills/   — loaded via the SDK and added as a "skills" feature
+//
+// Missing files and directories are ignored, and duplicate directories are
+// searched once. AGENT.md content augments (never replaces) the base backstory.
+func LoadProjectContext(cfg *Config, dirs ...string) error {
+	seen := map[string]bool{}
+	var search []string
+	for _, d := range dirs {
+		if d == "" || seen[d] {
+			continue
+		}
+		seen[d] = true
+		search = append(search, d)
+	}
+
+	base := cfg.Agent.Backstory
+	if base == "" {
+		base = DefaultBackstory
+	}
+
+	var instructions []string
+	var skillDirs []string
+	for _, d := range search {
+		if data, err := os.ReadFile(filepath.Join(d, agentFile)); err == nil {
+			if s := strings.TrimSpace(string(data)); s != "" {
+				instructions = append(instructions, s)
+			}
+		}
+		for _, sub := range skillSubdirs {
+			skillDirs = append(skillDirs, filepath.Join(d, sub))
+		}
+	}
+
+	if len(instructions) > 0 {
+		cfg.Agent.Backstory = base + "\n\n" + projectContext + "\n\n" + strings.Join(instructions, "\n\n---\n\n")
+	}
+
+	res, err := agent.LoadSkills(skillDirs)
+	if err != nil {
+		return fmt.Errorf("load skills: %w", err)
+	}
+	if skills := res.GetSkills(); len(skills) > 0 {
+		feature := agent.CreateSkillsFeature(skills)
+		options, _ := feature["options"].(map[string]interface{})
+		cfg.Features = append(cfg.Features, config.Feature{Name: skillsFeature, Options: options})
+	}
+
+	return nil
+}
 
 // Run executes one autonomous coding task, rendering the agent's activity in the
 // read-only TUI. The agent's file and shell tools operate on the current working
@@ -79,6 +153,9 @@ func Run(ctx context.Context, cfg Config, task string) error {
 		Tools:         agent.DefaultTools(),
 		MaxIterations: cfg.Agent.MaxIterations,
 	}
+	if feats := sdkFeatures(cfg.Features); len(feats) > 0 {
+		opts.Extensions = &types.ConversationCompleteRequestExtensions{Features: feats}
+	}
 
 	return tui.Run(ctx, client, tui.Meta{
 		Task:     task,
@@ -87,4 +164,16 @@ func Run(ctx context.Context, cfg Config, task string) error {
 		ShowDiff: cfg.UI.Diff,
 		Plain:    cfg.UI.Plain,
 	}, opts)
+}
+
+// sdkFeatures converts the configured features into the SDK's feature type.
+func sdkFeatures(features []config.Feature) []types.CompleteFeature {
+	if len(features) == 0 {
+		return nil
+	}
+	out := make([]types.CompleteFeature, 0, len(features))
+	for _, f := range features {
+		out = append(out, types.CompleteFeature{Name: f.Name, Options: f.Options})
+	}
+	return out
 }

--- a/zot_test.go
+++ b/zot_test.go
@@ -1,0 +1,77 @@
+package zot
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadProjectContext(t *testing.T) {
+	configDir := t.TempDir()
+	workDir := t.TempDir()
+
+	// A global AGENT.md in the config dir and a project one in the work dir.
+	mustWrite(t, filepath.Join(configDir, "AGENT.md"), "GLOBAL CONVENTIONS")
+	mustWrite(t, filepath.Join(workDir, "AGENT.md"), "PROJECT CONVENTIONS")
+
+	// A skill in each location: plain "skills/" in the config dir and hidden
+	// ".skills/" in the project dir — both layouts must be picked up.
+	mustWrite(t, filepath.Join(configDir, "skills", "greet", "SKILL.md"),
+		"---\nname: greet\ndescription: say hello\n---\nbody")
+	mustWrite(t, filepath.Join(workDir, ".skills", "deploy", "SKILL.md"),
+		"---\nname: deploy\ndescription: ship it\n---\nbody")
+
+	cfg := Config{}
+	if err := LoadProjectContext(&cfg, configDir, workDir); err != nil {
+		t.Fatalf("LoadProjectContext: %v", err)
+	}
+
+	// Backstory keeps the default and appends both AGENT.md files in order.
+	for _, want := range []string{DefaultBackstory[:20], "GLOBAL CONVENTIONS", "PROJECT CONVENTIONS"} {
+		if !strings.Contains(cfg.Agent.Backstory, want) {
+			t.Errorf("backstory missing %q", want)
+		}
+	}
+	if i, j := strings.Index(cfg.Agent.Backstory, "GLOBAL"), strings.Index(cfg.Agent.Backstory, "PROJECT"); i > j {
+		t.Error("expected config-dir AGENT.md to appear before work-dir AGENT.md")
+	}
+
+	// A single skills feature carrying both skills.
+	var skills *Feature
+	for i := range cfg.Features {
+		if cfg.Features[i].Name == "skills" {
+			skills = &cfg.Features[i]
+		}
+	}
+	if skills == nil {
+		t.Fatal("expected a skills feature to be added")
+	}
+	list, _ := skills.Options["skills"].([]map[string]string)
+	if len(list) != 2 {
+		t.Fatalf("expected 2 skills, got %d (%v)", len(list), skills.Options["skills"])
+	}
+}
+
+func TestLoadProjectContextNoFiles(t *testing.T) {
+	cfg := Config{}
+	if err := LoadProjectContext(&cfg, t.TempDir()); err != nil {
+		t.Fatalf("LoadProjectContext: %v", err)
+	}
+	if cfg.Agent.Backstory != "" {
+		t.Error("expected backstory untouched when no AGENT.md is present")
+	}
+	if len(cfg.Features) != 0 {
+		t.Error("expected no features when no skills are present")
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `incubator/openzot/tool` on branch `next` → `main`.