### PR TITLE
Release openzot-tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to zot, following [Keep a Changelog](https://keepachangelog.
 
 ### Features
 
-- Initial release of `zot`, an autonomous coding agent you watch, not drive. Hand it a single task on the command line and it works the problem on its own - reading files, editing them, and running shell commands - while the terminal streams a live, read-only view of every step.
+- Initial release of `zot`, an autonomous coding agent. Brief it once and it works the problem on its own - reading files, editing them, and running shell commands - while a read-only view streams every step. No prompting, no babysitting.
 - Autonomy is driven by the ChatBotKit Go SDK's `agent.ExecuteWithTools` loop (plan → act → observe → progress → exit) with `agent.DefaultTools()` (`read`, `write`, `edit`, `exec`) as the coding toolbox.
 - Read-only [Bubble Tea](https://github.com/charmbracelet/bubbletea) viewer with a scrollable activity log, per-tool styling, live narration, and a header showing model, working directory, iteration, tool, and edit counters plus elapsed time. The UI has no text input by design.
 - Layered configuration: built-in defaults < `~/.config/zot/config.yaml` < `ZOT_*` environment variables, with the API secret read from the platform-standard `CHATBOTKIT_API_SECRET`. CLI flags (`--model`, `--dir`, `--max-iterations`, `--task-file`, `--config`) override the resolved config.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
+<p align="center">
+  <img src="https://zot.im/icon-dark.svg" alt="zot" width="96" height="96" />
+</p>
+
 <h1 align="center">zot</h1>
 
-**An autonomous coding agent for your terminal.** Brief it once on the command
-line and it plans, edits, and runs your code until the whole job is done - no
-prompting, no babysitting, no chat box. A read-only viewer streams every step.
+**An autonomous coding agent.** Brief it once and it plans, edits, and runs your
+code until the whole job is done - no prompting, no babysitting, no chat box.
 
-<img width="1504" height="1080" alt="zot" src="https://github.com/user-attachments/assets/d12de01c-f13e-451c-93a3-d025b5b39dc6" />
+<p align="center">
+  <img width="1504" height="1080" alt="zot demo" src="https://github.com/user-attachments/assets/d12de01c-f13e-451c-93a3-d025b5b39dc6" />
+</p>
 
 ## Status
 
@@ -40,17 +45,6 @@ All of the autonomy comes from the
 front-end. It launches the agent in a goroutine and renders the event stream
 (`ToolCallStart`, `ToolCallEnd`, `Iteration`, token narration, `AgentExit`, …)
 into a scrollable, read-only viewport. The UI deliberately has no text input.
-
-## Why CBK?
-
-CBK.AI is a capable cloud harness: the agentic loop - model calls, tool
-orchestration, planning, iteration - runs server-side. That pushes the heavy
-lifting off the executable, so the local runtime stays minimal. The binary is
-small, and the code that remains here is tiny: load some config, wire the SDK's
-tools, and render events. That makes zot easy to read, reason about, and extend.
-
-The backend is an implementation detail behind the agent package. We may add
-other backends in the future; for now ChatBotKit keeps things lightweight.
 
 ## Prerequisites
 


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `incubator/openzot/tool` on branch `next` → `main`.