### PR TITLE
Release openzot-tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to zot, following [Keep a Changelog](https://keepachangelog.
 
 ## [0.6.0] - 2026-08-05
 
+### Features
+
+- `zot config` opens the config file in your `$EDITOR`, creating it from a commented template (embedded in the binary) on first run. This is the setup path - choose a backend and model and set your provider key by editing the file. `zot config path` prints the file location.
+
 ### Changed
 
 - **Breaking (config):** the `relay` backend no longer reads a `RELAY_API_KEY` environment variable. Its credential is your own provider key, set per model (`backends.relay.models.<model>.authorization`) or as a backend-level default (`backends.relay.authorization`), or inlined into `--model` as `<model>/authorization=<key>`. A relay run with no such key fails with an actionable error rather than falling back to an env var.

--- a/README.md
+++ b/README.md
@@ -336,23 +336,26 @@ ignored, which costs nothing by default (`BUZZ_ACP_MCP_COMMAND` is empty).
 
 ## Backends
 
-A run targets a **backend** - the provider zot talks to. Three ship built in:
+A run targets a **backend** - the provider zot talks to. zot defaults to
+**`relay`**; the ChatBotKit backends are an alternative for account holders. Pick
+one with `--backend` or `default_backend` in config.
 
-| Backend      | Endpoint                     | Auth style | Credential              |
-| ------------ | ---------------------------- | ---------- | ----------------------- |
-| `relay`      | `https://relay.cbk.ai`       | per-model  | provider key per model  |
-| `cbk`        | `https://api.cbk.ai`         | Bearer     | `CBK_API_SECRET`        |
-| `chatbotkit` | `https://api.chatbotkit.com` | Bearer     | `CHATBOTKIT_API_SECRET` |
+| Backend      | Endpoint                     | Auth style | Credential                   |
+| ------------ | ---------------------------- | ---------- | ---------------------------- |
+| `relay`      | `https://relay.cbk.ai`       | per-model  | your provider key, per model |
+| `cbk`        | `https://api.cbk.ai`         | Bearer     | `CBK_API_SECRET`             |
+| `chatbotkit` | `https://api.chatbotkit.com` | Bearer     | `CHATBOTKIT_API_SECRET`      |
 
-zot defaults to **`relay`**. Pick another with `--backend` (or `default_backend`
-in config). The model is resolved against the chosen backend, so it must be one
-that backend serves.
+The model is resolved against the chosen backend, so it must be one that backend
+serves.
 
-The two ChatBotKit backends authenticate with a Bearer token. The **relay is
-different**: it authenticates each model with *its own provider key*, carried
-inside the model string as `<model>/authorization=<key>` - because on the relay
-each model is a different provider (Z.AI, Moonshot, DeepSeek, …) with a different
-key. So relay auth is configured **per model**:
+### `relay` — the default (bring your own key)
+
+The CBK Relay is a free proxy, and **there is no relay API key.** It
+authenticates each model with _your own provider key_, carried inside the model
+string as `<model>/authorization=<key>` - because on the relay each model is a
+different provider (Z.AI, Moonshot, DeepSeek, …) with its own key. So you set the
+key **per model** in config (paste it literally, or reference an env var):
 
 ```yaml
 default_backend: relay
@@ -361,31 +364,35 @@ backends:
     # authorization: $ZAI_API_KEY   # optional: one default key for all relay models
     models:
       glm-5.2:
-        authorization: $ZAI_API_KEY
+        authorization: $ZAI_API_KEY      # or paste the key literally
       kimi-k3:
         authorization: $MOONSHOT_API_KEY
       deepseek-v4-flash:
         authorization: $DEEPSEEK_API_KEY
 ```
 
-There is no single relay API key - the credential is your own provider key, set
-per model (or as a backend-level default) in config.
-
 ```bash
 export ZAI_API_KEY="sk-..."
-zot --model glm-5.2 "…"          # → sends model glm-5.2/authorization=sk-... to the relay
-
-# You can also inline the key yourself; zot leaves it untouched:
-zot --model 'glm-5.2/authorization=sk-...' "…"
-
-# The ChatBotKit backends just need their Bearer token:
-export CBK_API_SECRET="..."
-zot --backend cbk --model kimi-k3 "…"
+zot --model glm-5.2 "…"                           # sends glm-5.2/authorization=sk-... to the relay
+zot --model 'glm-5.2/authorization=sk-...' "…"    # or inline it; zot leaves it as-is
 ```
 
 zot composes the `authorization=` param onto the model automatically from the
-per-model (or backend-level) config; a key you inline into `--model` yourself is
-left as-is.
+per-model (or backend-level) config; a key you inline into `--model` is left as-is.
+
+### `cbk` / `chatbotkit` — ChatBotKit account backends
+
+If you have a ChatBotKit account, target it directly with a Bearer token instead
+of bringing per-model keys. `cbk` and `chatbotkit` are the same platform on its
+two hosts and take the same credential value under their own variable:
+
+```bash
+export CBK_API_SECRET="..."          # or CHATBOTKIT_API_SECRET for --backend chatbotkit
+zot --backend cbk --model glm-5.2 "…"
+```
+
+Provide the token via that env var, or as `api_secret` under the backend in
+config.
 
 Each backend can also define **custom models** in the config; when `--model`
 matches a key, that entry's settings take priority (alias the real id, cap
@@ -418,8 +425,8 @@ Configuration is layered: built-in defaults < config file < `ZOT_*` environment
 variables < CLI flags. The config file is optional - env vars alone are enough.
 
 ```bash
-mkdir -p ~/.config/zot
-cp configs/zot.example.yaml ~/.config/zot/config.yaml
+zot config        # opens the config in $EDITOR, creating it from a template
+zot config path   # print the config file location
 ```
 
 Scalar fields have a matching `ZOT_<PATH>` env var (e.g. `agent.model` →

--- a/cmd/zot/main.go
+++ b/cmd/zot/main.go
@@ -24,6 +24,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -50,6 +51,16 @@ func run() error {
 	if len(os.Args) > 1 && os.Args[1] == acpCommand {
 		loadEnv(".")
 		return runACP(os.Args[2:])
+	}
+
+	// `zot config` opens the config file in $EDITOR, seeding it from the embedded
+	// template on first run. `zot config path` prints its location.
+	if len(os.Args) > 1 && os.Args[1] == "config" {
+		if len(os.Args) > 2 && os.Args[2] == "path" {
+			fmt.Println(config.DefaultConfigPath())
+			return nil
+		}
+		return editConfig()
 	}
 
 	configPath := flag.String("config", "", "path to zot config (default: "+config.DefaultConfigPath()+", optional)")
@@ -150,6 +161,51 @@ func loadEnv(dir string) {
 // resolveTask determines the single task string from --task-file or the
 // positional arguments. There is intentionally no interactive prompt: zot is a
 // viewer, not a chat client.
+// editConfig ensures the config file exists - seeding it from the embedded
+// template on first run - and opens it in the user's editor. This is the setup
+// path: configure the backend, model and provider key by editing the file.
+func editConfig() error {
+	path := config.DefaultConfigPath()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if err := os.WriteFile(path, zot.ExampleConfigYAML, 0o600); err != nil {
+			return fmt.Errorf("write config template: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Created %s from the template.\n", path)
+	}
+
+	editor := firstNonEmpty(os.Getenv("VISUAL"), os.Getenv("EDITOR"))
+	if editor == "" {
+		for _, candidate := range []string{"nano", "vi", "vim"} {
+			if _, err := exec.LookPath(candidate); err == nil {
+				editor = candidate
+				break
+			}
+		}
+	}
+	if editor == "" {
+		fmt.Println(path)
+		return fmt.Errorf("no editor found; set $EDITOR and re-run (the config is at the path above)")
+	}
+
+	cmd := exec.Command(editor, path)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return cmd.Run()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 func resolveTask(taskFile string, args []string) (string, error) {
 	if taskFile != "" {
 		data, err := os.ReadFile(taskFile)
@@ -176,6 +232,7 @@ func usage() {
 
 Usage:
   zot [flags] "your task in plain english"
+  zot config
   zot acp [flags]
 
 Examples:
@@ -183,7 +240,8 @@ Examples:
   zot --dir ./scratch "scaffold a tiny http server in go"
 
 Commands:
-  acp   serve the agent over the Agent Client Protocol (see zot acp -h)
+  config   edit the config file in $EDITOR (creates it on first run)
+  acp      serve the agent over the Agent Client Protocol (see zot acp -h)
 
 Flags:`)
 	flag.PrintDefaults()

--- a/configs/zot.example.yaml
+++ b/configs/zot.example.yaml
@@ -11,11 +11,12 @@
 #   agent.max_iterations  -> ZOT_AGENT_MAX_ITERATIONS
 #   default_backend       -> ZOT_DEFAULT_BACKEND
 #
-# Credentials are read from the environment by default (no ZOT_ prefix). Keep
-# secrets in the environment - the file only references them with $VAR:
-#   relay      -> a per-model provider key set in config (no single env var)
-#   cbk        -> CBK_API_SECRET
-#   chatbotkit -> CHATBOTKIT_API_SECRET   (cbk and chatbotkit take the same value)
+# Credentials: put the key DIRECTLY in this file, or reference an environment
+# variable with $VAR - either works. There is no single RELAY_API_KEY.
+#   relay      -> a per-model provider key, set in this file (see below)
+#   cbk        -> CBK_API_SECRET in the environment, or api_secret in this file
+#   chatbotkit -> CHATBOTKIT_API_SECRET in the environment, or api_secret here
+#                 (cbk and chatbotkit take the same credential value)
 
 agent:
   # Model name that drives the agent, from the ChatBotKit model catalogue and
@@ -43,30 +44,29 @@ agent:
 default_backend: relay
 
 backends:
-  # relay: CBK Relay. Auth is per model. Set a model's provider key with
-  # `authorization` (or a backend-level default applied to every model). A key is
-  # composed onto the model as glm-5.2/authorization=<key> before the request.
+  # relay: CBK Relay. Auth is per model: the key is carried inside the model
+  # string as "<model>/authorization=<key>". Put the key directly after
+  # `authorization:` (no quotes needed), or reference an env var with $VAR.
   relay:
     # base_url: 'https://relay.cbk.ai'
 
-    # Default provider key for every model on the relay (optional). Point it at
-    # your own provider key; use this if all your relay models share one key.
-    # authorization: '$ZAI_API_KEY'
+    # Optional: one default key applied to every relay model that has none.
+    # authorization: 'paste-a-key-here-or-$VAR'
 
-    # Per-model provider keys - the case one backend key cannot express. When
-    # --model matches a key here, its settings take priority. `model` aliases the
-    # real id; `authorization` is that model's provider key.
-    models: {}
-    #   glm-5.2:
-    #     authorization: $ZAI_API_KEY          # your Z.AI key
-    #   kimi-k3:
-    #     authorization: $MOONSHOT_API_KEY     # your Moonshot key
-    #   deepseek-v4-flash:
-    #     authorization: $DEEPSEEK_API_KEY     # your DeepSeek key
-    #   fast:
-    #     model: glm-5-turbo
-    #     authorization: $ZAI_API_KEY
-    #     max_iterations: 200
+    # Per-model provider keys - each open model is a different provider with its
+    # own key. `model` aliases a real id; `authorization` is that model's key.
+    # The default model is kept ready below - just fill in your key.
+    models:
+      glm-5.2:
+        authorization: ''                    # <- paste your Z.AI key here
+      # kimi-k3:
+      #   authorization: ''                   # your Moonshot key
+      # deepseek-v4-flash:
+      #   authorization: ''                   # your DeepSeek key
+      # fast:                                 # a custom alias: rename + cap iterations
+      #   model: glm-5-turbo
+      #   authorization: ''
+      #   max_iterations: 200
 
   # cbk: ChatBotKit at api.cbk.ai. Bearer credential, defaults to $CBK_API_SECRET.
   cbk:

--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,9 @@
+package zot
+
+import _ "embed"
+
+// ExampleConfigYAML is the commented starter config baked into the binary, used
+// by `zot config` to seed ~/.config/zot/config.yaml when it does not exist yet.
+//
+//go:embed configs/zot.example.yaml
+var ExampleConfigYAML []byte


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `incubator/openzot/tool` on branch `next` → `main`.