### PR TITLE
Release openzot-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,49 +4,64 @@
 
 <h1 align="center">zot</h1>
 
-**An automated software factory in a single binary.** Give it a software job and
-its autonomous coding harness plans, edits, runs, and verifies your code until
-the work is complete.
+**Hand it a software task and get back finished, tested code.** zot is an
+automated software factory in a single binary - an autonomous coding harness that
+plans, edits, runs, and verifies until the work is done.
 
 <p align="center">
   <img width="1504" height="1080" alt="zot demo" src="https://github.com/user-attachments/assets/d12de01c-f13e-451c-93a3-d025b5b39dc6" />
 </p>
 
-## Status
+## What you get
 
-zot is **0.x**: functional and in active use, with improvements landing release
-to release. Until 1.0 the CLI flags, config, and behavior may still change
-between versions - pin a version and skim the [changelog](CHANGELOG.md) before
-upgrading.
+Give it a brief and walk away:
+
+```bash
+zot "add rate limiting to the API, with tests"
+```
+
+zot reads the repo, writes and edits the code, runs the build and the tests, and
+fixes what it broke - on its own, from that one brief to a recorded outcome. When
+it stops you have a changed working tree and a full session log of every step it
+took. No chat loop, no approving each edit: one brief in, finished work out.
 
 ## Why zot exists
 
 Most coding tools optimize the conversation between a developer and an agent.
-zot optimizes the production run. A software brief goes in, the repository moves
-toward the requested outcome, and a verified working tree comes out.
+zot optimizes the production run: it drives the whole job from one brief, without
+a follow-up prompt at every step and without a hosted engine.
 
-The factory is powered by an autonomous coding harness that runs entirely in the
-binary. It drives the whole run from one brief - the agent plans, edits, runs
-commands, and keeps going until it records an outcome - without waiting for
-follow-up prompts at every step, and without a hosted engine. zot talks straight to a model provider over the OpenAI-compatible API, so
-all you need is a provider key: OpenAI, Anthropic, Groq, Mistral, DeepSeek,
-OpenRouter, a local Ollama, or anything else that speaks the same API. No
-account is required beyond the provider's own, and nothing is sent anywhere
-except the provider you configure.
+It talks straight to a model provider over the OpenAI-compatible API - OpenAI,
+Anthropic, Groq, Mistral, DeepSeek, OpenRouter, a local Ollama, or anything else
+that speaks the same API - so all you need is a provider key. No account beyond
+the provider's own, and nothing is sent anywhere except the provider you
+configure.
 
-## The factory model
+## Quickstart
 
-A run has a shape. The engine guarantees the first and last rows; the middle
-three are what a good run does, driven by the agent's tools and its instructions
-rather than enforced stages.
+Grab a prebuilt binary from the
+[releases page](https://github.com/openzot/openzot/releases) - no toolchain
+required:
 
-| Stage  | What happens                                                                                                              |
-| ------ | ------------------------------------------------------------------------------------------------------------------------- |
-| Brief  | zot takes one task - held in the system prompt - plus `AGENT.md` and skills                                               |
-| Plan   | the agent lays out an ordered plan with the `plan` tool                                                                   |
-| Build  | it reads and writes files and runs commands (builds, tests) in the repo                                                   |
-| Verify | it runs the tests and fixes what it broke - its own discipline, not yet an engine-enforced check (see below)              |
-| Finish | it records an outcome with `_success` / `_failure`; the engine ends the run only on that, never on prose that sounds done |
+```bash
+VERSION=vX.Y.Z; OS=linux ARCH=amd64      # e.g. darwin/arm64 on Apple Silicon
+curl -L "https://github.com/openzot/openzot/releases/download/${VERSION}/zot-${VERSION}-${OS}-${ARCH}.tar.gz" | tar xz
+mv "zot-${VERSION}-${OS}-${ARCH}/zot" ~/.local/bin/   # or any directory on your PATH
+```
+
+zot defaults to the **`zai`** backend running **`glm-5.2`**. Export a key and
+give it a job:
+
+```bash
+export ZAI_API_KEY="…"
+zot "add input validation to the signup handler and a test"
+```
+
+Any OpenAI-compatible provider works - `--backend anthropic --model
+claude-5-sonnet`, a local `--backend ollama`, gateways, or a custom endpoint; see
+[docs/backends.md](docs/backends.md). To build from source or run the container
+image, see [docs/development.md](docs/development.md) and
+[docs/docker.md](docs/docker.md).
 
 ## How it works
 
@@ -62,388 +77,29 @@ What sits under that is the part worth knowing about:
 
 - **Thread assembly** fits the conversation to the model's context window,
   newest-first, keeping tool calls paired with their results.
-- **Context strategy** decides what happens as that window fills, set by
-  `context_strategy`. **`compact`** (the default) summarises the older history
-  into a checkpoint with a model call once the provider's reported input usage
-  crosses ~90% of the window - so the run keeps a condensed memory of its early
-  turns instead of losing them; **`truncate`** skips the summary and simply
-  drops the oldest messages to fit. A checkpoint is pinned ahead of the
-  conversation and never summarised again, so a long run accumulates a chain of
-  segment summaries rather than re-condensing its own summaries into a lossy
-  summary-of-a-summary. Either way, an outright provider rejection falls back to
-  a no-model structural summary and retries. The trigger and its floors
-  (`compact_trigger_ratio`, `compact_min_tokens`, `compact_min_messages`) are
-  configurable.
+- **Context strategy** decides what happens as that window fills. `compact` (the
+  default) summarises the older history into a checkpoint with a model call, so a
+  long run keeps a condensed memory of its early turns instead of losing them;
+  `truncate` simply drops the oldest messages to fit. A checkpoint is preserved
+  verbatim and never re-summarised, and an outright provider rejection falls back
+  to a no-model summary and retries. Configurable - see
+  [configs/zot.example.yaml](configs/zot.example.yaml).
 - **Loop detection** notices when the agent has stopped making progress - four
   overlapping heuristics, because the obvious one (repeated messages) silently
   misses reasoning models, which interleave a thought between every tool call.
 - **Settle mode** ends a run when the agent _records_ an outcome, not when its
   prose happens to sound final. An answer containing "task completed" is not an
-  ending. Note the boundary, though: settle mode checks that the agent
-  _declared_ done, not that the work _is_ done. The agent verifies its own work
-  by running the tests (its instructions tell it to); zot does not yet
-  independently gate the outcome on a check of its own.
+  ending. Note the boundary, though: settle mode checks that the agent _declared_
+  done, not that the work _is_ done. The agent verifies its own work by running
+  the tests (its instructions tell it to); zot does not yet independently gate
+  the outcome on a check of its own.
 - **Session logs** record every run to disk as it happens, so a run nobody
-  watched is still answerable afterwards - and so it can be picked up again.
-
-`zot` itself is a [Bubble Tea](https://github.com/charmbracelet/bubbletea)
-front-end for that production run. It launches the harness in a goroutine and
-renders the event stream (`ToolCallStart`, `ToolCallEnd`, `Iteration`, token
-narration, `AgentExit`, …) into a scrollable, read-only viewport. The UI
-deliberately has no text input.
-
-## Prerequisites
-
-- A key for whichever model provider you want to use
-- Go 1.26+ - only if you build from source
-
-## Provider credentials
-
-zot defaults to the **`zai`** backend running **`glm-5.2`**, and reads
-`ZAI_API_KEY`:
-
-```bash
-export ZAI_API_KEY="…"
-zot "add input validation to the signup handler and a test"
-```
-
-Every built-in backend reads its own conventional variable - `OPENAI_API_KEY`,
-`ANTHROPIC_API_KEY`, `GROQ_API_KEY`, `MISTRAL_API_KEY`, `DEEPSEEK_API_KEY`,
-`OPENROUTER_API_KEY`, `TOGETHER_API_KEY`, `CEREBRAS_API_KEY`, `XAI_API_KEY`,
-`MOONSHOT_API_KEY`, `DASHSCOPE_API_KEY`, `AI_GATEWAY_API_KEY` - so switching
-provider is a pair of flags:
-
-```bash
-export ANTHROPIC_API_KEY="sk-ant-…"
-zot --backend anthropic --model claude-5-sonnet "…"
-```
-
-Give the model as well as the backend. The default model is `glm-5.2` and it
-only means something on `zai`; a backend and a model that cannot talk to each
-other fail as a provider error rather than a configuration one, which is much
-harder to read.
-
-A local model needs no key at all:
-
-```bash
-zot --backend ollama --model llama-4 "…"
-```
-
-To make a different pair the default, set both in config:
-
-```yaml
-# ~/.config/zot/config.yaml
-default_backend: openai
-agent:
-  model: gpt-5.4-mini
-```
-
-Anything else that speaks the OpenAI chat-completions API works too - see
-[Any other provider](#any-other-provider).
-
-Any key can equally live in the config file
-(`~/.config/zot/config.yaml`, or the path given to `--config`), including as a
-`$ENV_VAR` reference so no secret is written to disk:
-
-```yaml
-# ~/.config/zot/config.yaml
-backends:
-  openai:
-    api_key: '$OPENAI_API_KEY'
-```
-
-## Developer builds
-
-`make build` produces a release binary. `make dev` produces a developer one, and
-the difference is a security boundary rather than a convenience:
-
-|                           | release (`make build`) | developer (`make dev`) |
-| ------------------------- | ---------------------- | ---------------------- |
-| reads `.env` from `--dir` | no                     | yes                    |
-
-zot runs unattended with a provider key and a shell tool, so a released binary
-must not take credentials from whatever directory it was pointed at - running it
-against a repository you cloned to review would otherwise be enough to load a
-stray committed `.env` into the process that is about to run commands. Released
-builds read credentials from the config file and the real environment, both of
-which you chose deliberately.
-
-The switch is a build tag (`-tags dev`) and defaults to off, so a build that
-forgets it loses a convenience rather than a boundary. `zot --version` prints
-which kind you have.
-
-## Install
-
-### Download a release (recommended)
-
-Grab a prebuilt binary from the
-[releases page](https://github.com/openzot/openzot/releases) - no toolchain
-required. Pick the archive for your platform (`linux-amd64`, `linux-arm64`,
-`darwin-amd64`, `darwin-arm64`, `windows-amd64`):
-
-```bash
-VERSION=vX.Y.Z           # replace with the latest release tag
-OS=linux ARCH=amd64      # e.g. darwin/arm64 on Apple Silicon
-curl -L "https://github.com/openzot/openzot/releases/download/${VERSION}/zot-${VERSION}-${OS}-${ARCH}.tar.gz" | tar xz
-mv "zot-${VERSION}-${OS}-${ARCH}/zot" ~/.local/bin/ # or any directory on your PATH
-zot --version
-```
-
-### Build from source
-
-Requires Go 1.26+.
-
-```bash
-git clone https://github.com/openzot/openzot
-cd openzot
-make                     # lists the targets
-make build               # or: go build -o zot ./cmd/zot
-./zot --version
-```
-
-`make` on its own prints the targets rather than assuming one, because `build`
-and `dev` produce binaries that differ in what they will read from disk. `make
-build` stamps the version in; `make test`, `make race`, `make cover`, `make vet`
-and `make cross GOOS=… GOARCH=…` are also available.
-
-To bake a configuration - model, backend, even the provider key - _into_ the
-binary so it needs nothing at the destination, build with `-tags portable`. The
-compiled-in config overrides the runtime file and environment, which is the
-point: nothing at the destination can redirect it. See
-[docs/portable-config.md](docs/portable-config.md) for the recipe and the
-trade-offs (chiefly: a baked key is extractable, so the artifact becomes the
-secret).
-
-### Docker
-
-Official Linux amd64 and arm64 images are published to GitHub Container
-Registry from the same version tag as the binary release. The agent works in
-`/workspace` - mount the checkout you are happy for it to change there:
-
-```bash
-docker pull ghcr.io/openzot/openzot:latest
-
-docker run --rm -it \
-  --user "$(id -u):$(id -g)" \
-  --env HOME=/tmp \
-  --env ZAI_API_KEY \
-  --volume "$PWD":/workspace \
-  ghcr.io/openzot/openzot:latest "add a /health endpoint and a test for it"
-```
-
-`--user` makes the files the agent writes belong to you rather than the image's
-`zot` user (uid 10001), and `HOME=/tmp` gives that user a writable home so
-tools like `git` can store their own config. Both are only needed for host bind
-mounts; with a named volume the defaults are fine.
-
-The entrypoint **is** `zot`, so everything after the image name is zot's own
-viewer; without a TTY it streams plain text, which is what you want in CI:
-
-```bash
-docker run --rm \
-  --user "$(id -u):$(id -g)" --env HOME=/tmp \
-  --env ZAI_API_KEY \
-  --volume "$PWD":/workspace \
-  ghcr.io/openzot/openzot:latest --max-iterations 40 --task-file TASK.md | tee run.log
-```
-
-A container is also the cleanest answer to [Safety](#️-safety): file writes and
-shell commands are confined to the volume you mounted, so a run cannot reach the
-rest of your machine. See [docs/docker.md](docs/docker.md) for credentials,
-config and `AGENT.md` mounts, and hardening flags.
-
-## Backends
-
-zot ships with a backend for each common provider. Pick one with `--backend`, or
-set `default_backend` in config.
-
-| Backend      | Endpoint                          | Credential from      |
-| ------------ | --------------------------------- | -------------------- |
-| `openai`     | `https://api.openai.com/v1`       | `OPENAI_API_KEY`     |
-| `anthropic`  | `https://api.anthropic.com/v1`    | `ANTHROPIC_API_KEY`  |
-| `groq`       | `https://api.groq.com/openai/v1`  | `GROQ_API_KEY`       |
-| `mistral`    | `https://api.mistral.ai/v1`       | `MISTRAL_API_KEY`    |
-| `deepseek`   | `https://api.deepseek.com/v1`     | `DEEPSEEK_API_KEY`   |
-| `openrouter` | `https://openrouter.ai/api/v1`    | `OPENROUTER_API_KEY` |
-| `together`   | `https://api.together.xyz/v1`     | `TOGETHER_API_KEY`   |
-| `cerebras`   | `https://api.cerebras.ai/v1`      | `CEREBRAS_API_KEY`   |
-| `xai`        | `https://api.x.ai/v1`             | `XAI_API_KEY`        |
-| `moonshot`   | `https://api.moonshot.cn/v1`      | `MOONSHOT_API_KEY`   |
-| `zai`        | `https://api.z.ai/api/paas/v4`    | `ZAI_API_KEY`        |
-| `qwen`       | DashScope compatible mode         | `DASHSCOPE_API_KEY`  |
-| `vercel`     | `https://ai-gateway.vercel.sh/v1` | `AI_GATEWAY_API_KEY` |
-| `ollama`     | `http://localhost:11434/v1`       | none                 |
-
-### Gateways and prefixed models
-
-`openrouter` and `vercel` are model gateways: one endpoint fronting many
-providers, addressed by a provider-qualified model name like `openai/gpt-4o` or
-`anthropic/claude-5-sonnet`. zot resolves the model's real context window behind
-the prefix, and - because a model is the same model whichever gateway serves it -
-you can give a **bare** name and zot supplies each gateway's own prefix from its
-catalogue:
-
-```bash
-export OPENROUTER_API_KEY="sk-..."
-zot --backend openrouter --model glm-5.2 "…"   # sent as z-ai/glm-5.2
-
-export AI_GATEWAY_API_KEY="..."                # Vercel AI Gateway
-zot --backend vercel --model glm-5.2 "…"       # sent as zai/glm-5.2
-```
-
-A name you qualify yourself (`--model z-ai/glm-5.2`) is always sent as-is, and a
-model zot has not catalogued passes through bare for the gateway to resolve.
-
-**Cloudflare AI Gateway** is supported too, but its endpoint carries your account
-and gateway ids, so there is no fixed URL to ship - configure it as a backend
-with the `cloudflare` provider and your gateway's compat URL:
-
-```yaml
-default_backend: cloudflare
-backends:
-  cloudflare:
-    provider: cloudflare
-    base_url: https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/compat
-    api_key: '$OPENAI_API_KEY' # the downstream provider's key
-    # headers: { cf-aig-authorization: 'Bearer <gateway-token>' }  # if the gateway is authenticated
-```
-
-### Any other provider
-
-Anything that speaks the OpenAI chat-completions API works. Name a backend,
-give it a base URL and a key:
-
-```yaml
-default_backend: mygateway
-
-backends:
-  mygateway:
-    provider: custom
-    base_url: https://gateway.internal.example.com/v1
-    api_key: '$GATEWAY_KEY'
-```
-
-The endpoint must be `https` unless it is loopback, and a custom endpoint needs
-its own key - a credential is scoped to the host it was issued for, and zot will
-not forward one to a URL you just typed.
-
-### The Responses API
-
-On OpenAI, reasoning models use the
-[Responses API](https://platform.openai.com/docs/api-reference/responses)
-automatically. It carries reasoning state between tool rounds as an opaque item
-the model resumes from; chat-completions has nowhere to put it, so a reasoning
-model driven that way re-derives its thinking on every round.
-
-Only OpenAI implements it today, so everywhere else stays on chat-completions.
-Override per backend if a gateway supports it:
-
-```yaml
-backends:
-  mygateway:
-    provider: custom
-    base_url: https://gateway.example.com/v1
-    use_responses: true # or disable_responses: true
-```
-
-## Configuration
-
-Configuration is layered: built-in defaults < config file < `ZOT_*` environment
-variables < CLI flags. The config file is optional - env vars alone are enough.
-
-```bash
-zot config        # opens the config in $EDITOR, creating it from a template
-zot config path   # print the config file location
-```
-
-Scalar fields have a matching `ZOT_<PATH>` env var (e.g. `agent.model` →
-`ZOT_AGENT_MODEL`, `default_backend` → `ZOT_DEFAULT_BACKEND`). Provider
-credentials come from their own conventional variables (`OPENAI_API_KEY`,
-`ANTHROPIC_API_KEY`, …) and so need no `ZOT_` prefix; they can equally be set in
-config, referencing a variable you export. See
-[configs/zot.example.yaml](configs/zot.example.yaml).
-
-### Flags
-
-`zot --help` lists them all. The ones worth knowing:
-
-| Flag                                          | Effect                                                             |
-| --------------------------------------------- | ------------------------------------------------------------------ |
-| `--backend` / `--model`                       | which provider and model to run against                            |
-| `--dir`                                       | the directory the agent reads, writes and runs commands in         |
-| `--max-iterations`                            | cap the agentic rounds; the default is deliberately large          |
-| `--task-file`                                 | read the brief from a file instead of the command line             |
-| `--resume` / `--session-dir` / `--no-session` | see [Sessions](#sessions)                                          |
-| `--diff`                                      | show a syntax-highlighted diff under each write                    |
-| `--plain`                                     | stream unstyled output; auto-enabled when stdout is not a terminal |
-| `--config`                                    | use a specific config file                                         |
-
-### Controls
-
-Because the agent is autonomous, the only keys are for viewing:
-
-| Key           | Action             |
-| ------------- | ------------------ |
-| `↑` / `↓`     | scroll the log     |
-| `PgUp`/`PgDn` | page the log       |
-| `g` / `G`     | jump to top/bottom |
-| `q`           | quit               |
-
-## Sessions
-
-Every run is written to `~/.local/state/zot/sessions/` as it happens - one JSON
-object per line, holding the brief, the model, every message, every tool call
-and how it ended.
-
-That matters because an autonomous run is unattended by definition: nobody
-watched it, and by the time you look the terminal is gone. The log is what turns
-"it failed overnight" into something you can answer.
-
-```bash
-# what has run, newest first
-zot sessions
-
-# read one
-cat ~/.local/state/zot/sessions/20260805-155859.jsonl | jq .
-
-# pick up where it stopped - the agent keeps everything it already knew
-zot --resume last "now add the tests you skipped"
-
-# or continue the original brief, unchanged
-zot --resume last
-```
-
-`--resume` takes a session id, a path, or `last`. A resumed run writes its own
-log and records which session it continued, so a chain of continued runs stays
-reconstructable.
-
-The log is appended and flushed line by line, so it is readable while the run is
-still going and a killed run still leaves everything up to the kill. Use
-`--no-session` to record nothing, or `--session-dir` (or `ZOT_SESSION_DIR`) to
-put the logs somewhere else.
-
-## Project context (`AGENT.md` & skills)
-
-On startup zot folds in context from two places - the **config directory**
-(`~/.config/zot/`, global) and the **working directory** (`--dir`, per-project):
-
-- **`AGENT.md`** - at the **root** of either directory; its contents are
-  appended to the agent's instructions (config first, then project). Use it for
-  conventions the agent should always follow.
-- **skills** - each `<name>/SKILL.md` (with `name` / `description` YAML front
-  matter) is described to the agent in its instructions, and the agent reads a
-  skill's full file on demand when it's relevant. Both
-  **`.skills/`** (typical at a project root) and **`skills/`** are searched.
-
-```
-~/.config/zot/          ./ (your project, --dir)
-├── AGENT.md            ├── AGENT.md
-└── skills/             └── .skills/
-    └── greet/              └── deploy/
-        └── SKILL.md            └── SKILL.md
-```
-
-Everything here is optional - missing files and directories are ignored.
+  watched is still answerable afterwards - and so it can be picked up again with
+  `--resume` (see [docs/configuration.md](docs/configuration.md#sessions)).
+
+`zot` itself is a read-only [Bubble Tea](https://github.com/charmbracelet/bubbletea)
+viewer over that run - it renders the event stream into a scrollable log and has
+no text input, because the run is autonomous.
 
 ## Sub-agents and coordination
 
@@ -489,33 +145,26 @@ and then removed from the process environment before the agent starts, so its
 shell commands do not inherit those API keys. Other secrets already present in
 the environment or readable from disk remain accessible to those commands.
 
-The published [container image](#docker) is the practical way to bound this: the
-agent can only touch the volume you mounted, and `docker run` gives you the rest
-of the levers (read-only root, dropped capabilities, resource limits) in one
-place. [docs/docker.md](docs/docker.md) covers them.
+The published [container image](docs/docker.md) is the practical way to bound
+this: the agent can only touch the volume you mounted, and `docker run` gives you
+the rest of the levers (read-only root, dropped capabilities, resource limits) in
+one place.
 
-## Architecture
+## Status
 
-| Path                   | Responsibility                                                                 |
-| ---------------------- | ------------------------------------------------------------------------------ |
-| `cmd/zot/`             | the binary: flag parsing, sessions, working dir, then `zot.Run`                |
-| `zot.go`               | embeddable core: builds the provider client + agent options and runs it        |
-| `agent/`               | the public harness: `ExecuteWithTools`, tools, skills, events                  |
-| `internal/loop/`       | the agentic loop: budgets, guards, settle mode, message hygiene                |
-| `internal/thread/`     | context-window assembly and the four loop-detection heuristics                 |
-| `internal/compaction/` | condensing older history into a summary when the window fills                  |
-| `internal/provider/`   | the `Transport` seam: chat-completions and the Responses API                   |
-| `internal/catalogue/`  | what each model's context window and capabilities are                          |
-| `internal/tokenizer/`  | BPE token counting with embedded vocabularies                                  |
-| `internal/session/`    | JSONL run logs: write, read, list, resume                                      |
-| `internal/config/`     | layered config (defaults < file < env < compiled-in), XDG paths, env overrides |
-| `internal/buildinfo/`  | release vs developer build, and what that changes                              |
-| `internal/version/`    | build-time version stamping and GitHub update checks                           |
-| `internal/tui/`        | the Bubble Tea read-only viewer (model, render, styles, agent bridge)          |
-| `configs/`             | example configuration                                                          |
+zot is **0.x**: functional and in active use, with improvements landing release
+to release. Until 1.0 the CLI flags, config, and behavior may still change
+between versions - pin a version and skim the [changelog](CHANGELOG.md) before
+upgrading.
 
-Releasing is driven by the `VERSION` file and the GitHub workflows - see
-[RELEASES.md](RELEASES.md) and [CHANGELOG.md](CHANGELOG.md).
+## Documentation
+
+- [docs/backends.md](docs/backends.md) - providers, credentials, gateways, custom endpoints, the Responses API
+- [docs/configuration.md](docs/configuration.md) - config file, flags, controls, sessions, `AGENT.md` & skills
+- [docs/development.md](docs/development.md) - building from source, release vs developer builds, the codebase map
+- [docs/portable-config.md](docs/portable-config.md) - baking the configuration into the binary
+- [docs/docker.md](docs/docker.md) - running the container image
+- [CHANGELOG.md](CHANGELOG.md) · [RELEASES.md](RELEASES.md)
 
 ## Ecosystem
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,139 @@
+# Backends: connecting zot to a provider
+
+zot talks straight to a model provider over the OpenAI-compatible chat-completions
+API - there is no gateway or account in between. A backend is a URL and a
+credential; zot ships with one for each common provider. Pick one per run with
+`--backend`, or set `default_backend` in config.
+
+For the agent itself - the run loop, tools, safety - see the [README](../README.md).
+
+## The built-in backends
+
+| Backend      | Endpoint                          | Credential from      |
+| ------------ | --------------------------------- | -------------------- |
+| `openai`     | `https://api.openai.com/v1`       | `OPENAI_API_KEY`     |
+| `anthropic`  | `https://api.anthropic.com/v1`    | `ANTHROPIC_API_KEY`  |
+| `groq`       | `https://api.groq.com/openai/v1`  | `GROQ_API_KEY`       |
+| `mistral`    | `https://api.mistral.ai/v1`       | `MISTRAL_API_KEY`    |
+| `deepseek`   | `https://api.deepseek.com/v1`     | `DEEPSEEK_API_KEY`   |
+| `openrouter` | `https://openrouter.ai/api/v1`    | `OPENROUTER_API_KEY` |
+| `together`   | `https://api.together.xyz/v1`     | `TOGETHER_API_KEY`   |
+| `cerebras`   | `https://api.cerebras.ai/v1`      | `CEREBRAS_API_KEY`   |
+| `xai`        | `https://api.x.ai/v1`             | `XAI_API_KEY`        |
+| `moonshot`   | `https://api.moonshot.cn/v1`      | `MOONSHOT_API_KEY`   |
+| `zai`        | `https://api.z.ai/api/paas/v4`    | `ZAI_API_KEY`        |
+| `qwen`       | DashScope compatible mode         | `DASHSCOPE_API_KEY`  |
+| `vercel`     | `https://ai-gateway.vercel.sh/v1` | `AI_GATEWAY_API_KEY` |
+| `ollama`     | `http://localhost:11434/v1`       | none                 |
+
+## Credentials
+
+Each built-in backend reads its provider's conventional variable, so switching
+provider is a pair of flags:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-…"
+zot --backend anthropic --model claude-5-sonnet "…"
+```
+
+Give the model as well as the backend. The default model is `glm-5.2` and it
+only means something on `zai`; a backend and a model that cannot talk to each
+other fail as a provider error rather than a configuration one, which is much
+harder to read.
+
+A local model needs no key at all:
+
+```bash
+zot --backend ollama --model llama-4 "…"
+```
+
+To make a different pair the default, set both in config:
+
+```yaml
+# ~/.config/zot/config.yaml
+default_backend: openai
+agent:
+  model: gpt-5.4-mini
+```
+
+Any key can equally live in the config file (`~/.config/zot/config.yaml`, or the
+path given to `--config`), including as a `$ENV_VAR` reference so no secret is
+written to disk:
+
+```yaml
+backends:
+  openai:
+    api_key: '$OPENAI_API_KEY'
+```
+
+## Gateways and prefixed models
+
+`openrouter` and `vercel` are model gateways: one endpoint fronting many
+providers, addressed by a provider-qualified model name like `openai/gpt-4o` or
+`anthropic/claude-5-sonnet`. zot resolves the model's real context window behind
+the prefix, and - because a model is the same model whichever gateway serves it -
+you can give a **bare** name and zot supplies each gateway's own prefix from its
+catalogue:
+
+```bash
+export OPENROUTER_API_KEY="sk-..."
+zot --backend openrouter --model glm-5.2 "…"   # sent as z-ai/glm-5.2
+
+export AI_GATEWAY_API_KEY="..."                # Vercel AI Gateway
+zot --backend vercel --model glm-5.2 "…"       # sent as zai/glm-5.2
+```
+
+A name you qualify yourself (`--model z-ai/glm-5.2`) is always sent as-is, and a
+model zot has not catalogued passes through bare for the gateway to resolve.
+
+**Cloudflare AI Gateway** is supported too, but its endpoint carries your account
+and gateway ids, so there is no fixed URL to ship - configure it as a backend
+with the `cloudflare` provider and your gateway's compat URL:
+
+```yaml
+default_backend: cloudflare
+backends:
+  cloudflare:
+    provider: cloudflare
+    base_url: https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/compat
+    api_key: '$OPENAI_API_KEY' # the downstream provider's key
+    # headers: { cf-aig-authorization: 'Bearer <gateway-token>' }  # if the gateway is authenticated
+```
+
+## Any other provider
+
+Anything that speaks the OpenAI chat-completions API works. Name a backend, give
+it a base URL and a key:
+
+```yaml
+default_backend: mygateway
+
+backends:
+  mygateway:
+    provider: custom
+    base_url: https://gateway.internal.example.com/v1
+    api_key: '$GATEWAY_KEY'
+```
+
+The endpoint must be `https` unless it is loopback, and a custom endpoint needs
+its own key - a credential is scoped to the host it was issued for, and zot will
+not forward one to a URL you just typed.
+
+## The Responses API
+
+On OpenAI, reasoning models use the
+[Responses API](https://platform.openai.com/docs/api-reference/responses)
+automatically. It carries reasoning state between tool rounds as an opaque item
+the model resumes from; chat-completions has nowhere to put it, so a reasoning
+model driven that way re-derives its thinking on every round.
+
+Only OpenAI implements it today, so everywhere else stays on chat-completions.
+Override per backend if a gateway supports it:
+
+```yaml
+backends:
+  mygateway:
+    provider: custom
+    base_url: https://gateway.example.com/v1
+    use_responses: true # or disable_responses: true
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,104 @@
+# Configuration, flags, sessions & project context
+
+How to configure a run, the flags and keys, where the session logs live, and how
+zot picks up `AGENT.md` and skills. For choosing and configuring a provider, see
+[backends.md](backends.md); for the agent itself, the [README](../README.md).
+
+## The config file and env vars
+
+Configuration is layered: built-in defaults < config file < `ZOT_*` environment
+variables < CLI flags. The config file is optional - env vars alone are enough.
+
+```bash
+zot config        # opens the config in $EDITOR, creating it from a template
+zot config path   # print the config file location
+```
+
+Scalar fields have a matching `ZOT_<PATH>` env var (e.g. `agent.model` →
+`ZOT_AGENT_MODEL`, `default_backend` → `ZOT_DEFAULT_BACKEND`). Provider
+credentials come from their own conventional variables (`OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, …) and so need no `ZOT_` prefix; they can equally be set in
+config, referencing a variable you export. Every field is documented in
+[configs/zot.example.yaml](../configs/zot.example.yaml).
+
+## Flags
+
+`zot --help` lists them all. The ones worth knowing:
+
+| Flag                                          | Effect                                                             |
+| --------------------------------------------- | ------------------------------------------------------------------ |
+| `--backend` / `--model`                       | which provider and model to run against                            |
+| `--dir`                                       | the directory the agent reads, writes and runs commands in         |
+| `--max-iterations`                            | cap the agentic rounds; the default is deliberately large          |
+| `--task-file`                                 | read the brief from a file instead of the command line             |
+| `--resume` / `--session-dir` / `--no-session` | see [Sessions](#sessions)                                          |
+| `--diff`                                      | show a syntax-highlighted diff under each write                    |
+| `--plain`                                     | stream unstyled output; auto-enabled when stdout is not a terminal |
+| `--config`                                    | use a specific config file                                         |
+
+## Controls
+
+Because the agent is autonomous, the only keys are for viewing:
+
+| Key           | Action             |
+| ------------- | ------------------ |
+| `↑` / `↓`     | scroll the log     |
+| `PgUp`/`PgDn` | page the log       |
+| `g` / `G`     | jump to top/bottom |
+| `q`           | quit               |
+
+## Sessions
+
+Every run is written to `~/.local/state/zot/sessions/` as it happens - one JSON
+object per line, holding the brief, the model, every message, every tool call
+and how it ended.
+
+That matters because an autonomous run is unattended by definition: nobody
+watched it, and by the time you look the terminal is gone. The log is what turns
+"it failed overnight" into something you can answer.
+
+```bash
+# what has run, newest first
+zot sessions
+
+# read one
+cat ~/.local/state/zot/sessions/20260805-155859.jsonl | jq .
+
+# pick up where it stopped - the agent keeps everything it already knew
+zot --resume last "now add the tests you skipped"
+
+# or continue the original brief, unchanged
+zot --resume last
+```
+
+`--resume` takes a session id, a path, or `last`. A resumed run writes its own
+log and records which session it continued, so a chain of continued runs stays
+reconstructable.
+
+The log is appended and flushed line by line, so it is readable while the run is
+still going and a killed run still leaves everything up to the kill. Use
+`--no-session` to record nothing, or `--session-dir` (or `ZOT_SESSION_DIR`) to
+put the logs somewhere else.
+
+## Project context (`AGENT.md` & skills)
+
+On startup zot folds in context from two places - the **config directory**
+(`~/.config/zot/`, global) and the **working directory** (`--dir`, per-project):
+
+- **`AGENT.md`** - at the **root** of either directory; its contents are
+  appended to the agent's instructions (config first, then project). Use it for
+  conventions the agent should always follow.
+- **skills** - each `<name>/SKILL.md` (with `name` / `description` YAML front
+  matter) is described to the agent in its instructions, and the agent reads a
+  skill's full file on demand when it's relevant. Both
+  **`.skills/`** (typical at a project root) and **`skills/`** are searched.
+
+```
+~/.config/zot/          ./ (your project, --dir)
+├── AGENT.md            ├── AGENT.md
+└── skills/             └── .skills/
+    └── greet/              └── deploy/
+        └── SKILL.md            └── SKILL.md
+```
+
+Everything here is optional - missing files and directories are ignored.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,73 @@
+# Building & developing zot
+
+Building from source, the two build variants and why they differ, and a map of
+the codebase. For running zot, see the [README](../README.md).
+
+## Build from source
+
+Requires Go 1.26+.
+
+```bash
+git clone https://github.com/openzot/openzot
+cd openzot
+make                     # lists the targets
+make build               # or: go build -o zot ./cmd/zot
+./zot --version
+```
+
+`make` on its own prints the targets rather than assuming one, because `build`
+and `dev` produce binaries that differ in what they will read from disk. `make
+build` stamps the version in; `make test`, `make race`, `make cover`, `make vet`
+and `make cross GOOS=… GOARCH=…` are also available.
+
+To bake a configuration - model, backend, even the provider key - _into_ the
+binary so it needs nothing at the destination, build with `-tags portable`. The
+compiled-in config overrides the runtime file and environment, which is the
+point: nothing at the destination can redirect it. See
+[portable-config.md](portable-config.md) for the recipe and the trade-offs
+(chiefly: a baked key is extractable, so the artifact becomes the secret).
+
+## Release vs developer builds
+
+`make build` produces a release binary. `make dev` produces a developer one, and
+the difference is a security boundary rather than a convenience:
+
+|                           | release (`make build`) | developer (`make dev`) |
+| ------------------------- | ---------------------- | ---------------------- |
+| reads `.env` from `--dir` | no                     | yes                    |
+
+zot runs unattended with a provider key and a shell tool, so a released binary
+must not take credentials from whatever directory it was pointed at - running it
+against a repository you cloned to review would otherwise be enough to load a
+stray committed `.env` into the process that is about to run commands. Released
+builds read credentials from the config file and the real environment, both of
+which you chose deliberately.
+
+The switch is a build tag (`-tags dev`) and defaults to off, so a build that
+forgets it loses a convenience rather than a boundary. `zot --version` prints
+which kind you have.
+
+## Architecture
+
+| Path                   | Responsibility                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| `cmd/zot/`             | the binary: flag parsing, sessions, working dir, then `zot.Run`                |
+| `zot.go`               | embeddable core: builds the provider client + agent options and runs it        |
+| `agent/`               | the public harness: `ExecuteWithTools`, tools, skills, events                  |
+| `internal/loop/`       | the agentic loop: budgets, guards, settle mode, message hygiene                |
+| `internal/thread/`     | context-window assembly and the four loop-detection heuristics                 |
+| `internal/compaction/` | condensing older history into a summary when the window fills                  |
+| `internal/provider/`   | the `Transport` seam: chat-completions and the Responses API                   |
+| `internal/catalogue/`  | what each model's context window and capabilities are                          |
+| `internal/tokenizer/`  | BPE token counting with embedded vocabularies                                  |
+| `internal/session/`    | JSONL run logs: write, read, list, resume                                      |
+| `internal/config/`     | layered config (defaults < file < env < compiled-in), XDG paths, env overrides |
+| `internal/buildinfo/`  | release vs developer build, and what that changes                              |
+| `internal/version/`    | build-time version stamping and GitHub update checks                           |
+| `internal/tui/`        | the Bubble Tea read-only viewer (model, render, styles, agent bridge)          |
+| `configs/`             | example configuration                                                          |
+
+Contributor conventions live in [AGENTS.md](../AGENTS.md) and
+[.agents/skills/](../.agents/skills/). Releasing is driven by the `VERSION` file
+and the GitHub workflows - see [RELEASES.md](../RELEASES.md) and
+[CHANGELOG.md](../CHANGELOG.md).

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -6,8 +6,10 @@ agent can only change what you mounted, and the usual `docker run` levers
 (dropped capabilities, a read-only root filesystem, resource limits) apply
 without zot having to implement a sandbox of its own.
 
-This document covers the published image. For the agent itself - flags, config,
-backends - see the [README](../README.md).
+This document covers the published image. For the agent itself see the
+[README](../README.md); for flags and config see
+[configuration.md](configuration.md), and for providers
+[backends.md](backends.md).
 
 ## The image
 
@@ -54,7 +56,7 @@ docker run --rm -it --env OPENAI_API_KEY --volume "$PWD":/workspace \
   ghcr.io/openzot/openzot:latest --backend openai --model gpt-5.4-mini "…"
 ```
 
-See [Backends](../README.md#backends) for the full list.
+See [backends.md](backends.md) for the full list.
 
 ```bash
 docker run --rm -it \
@@ -110,7 +112,7 @@ not write, and reading credentials out of it would mean a stray committed `.env`
 in the code under review could feed the process that is about to run shell
 commands. Pass credentials with `--env` or `--env-file`, where the value comes
 from your secret store. (A developer build, `make dev`, does read `.env`; see
-[Developer builds](../README.md#developer-builds).)
+[release vs developer builds](development.md#release-vs-developer-builds).)
 
 After zot loads its configuration, configured backend credentials are removed
 from the environment inherited by agent shell commands, so the task itself
@@ -234,7 +236,9 @@ and smoke-tests the same Dockerfile on every code push. See
 
 ## See also
 
-- [README](../README.md) - flags, config and backends
+- [README](../README.md) - what zot is
+- [configuration.md](configuration.md) - flags, config, sessions
+- [backends.md](backends.md) - providers and credentials
 - [Pantalk deployment](https://github.com/pantalk/pantalk/blob/main/docs/deployment.md) -
   putting a containerised agent into chat
 - [MCPShim deployment](https://github.com/mcpshim/mcpshim/blob/main/docs/deployment.md) -

--- a/docs/portable-config.md
+++ b/docs/portable-config.md
@@ -8,7 +8,7 @@ self-contained artifact that runs with no config file and nothing to set at the
 destination.
 
 For the runtime configuration model - the file, the environment, the flags - see
-the [README](../README.md#configuration). This document is only about the
+[configuration.md](configuration.md). This document is only about the
 compiled-in layer.
 
 ## When you would want this


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `incubator/openzot/tool` on branch `next` → `main`.