### PR TITLE
Release openzot-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ The harness is zot's own, in the [`agent`](agent) package:
 - `agent.DefaultTools()` gives it the toolbox: `read`, `write`, `list` and
   `shell` for the work, plus `plan` and `progress` to structure and narrate it.
 
+That package is importable, so the same engine drives more than coding:
+[Rook](https://github.com/pdparchitect/rook), an AI bug-hunting and security-audit
+agent, is built on it with its own toolset and skills.
+
 What sits under that is the part worth knowing about:
 
 - **Thread assembly** fits the conversation to the model's context window,
@@ -170,6 +174,7 @@ upgrading.
 
 | Project                                       | Role                                                           |
 | --------------------------------------------- | -------------------------------------------------------------- |
+| [Rook](https://github.com/pdparchitect/rook)  | An AI bug-hunting and security-audit agent built on zot's engine |
 | [Pantalk](https://github.com/pantalk/pantalk) | Connect coding agents to the chat platforms people already use |
 | [MCPShim](https://github.com/mcpshim/mcpshim) | Turn MCP servers and HTTP APIs into standard CLI commands      |
 | [crmkit](https://github.com/crmkit/crmkit)    | Give agents a shared CRM and system of record over HTTP or MCP |


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `incubator/openzot/tool` on branch `next` → `main`.