### PR TITLE
Release zot-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ sandbox. Point it at a disposable checkout, or run the
 
 ## Documentation
 
-- [docs/orders.md](docs/orders.md) - work orders, `zot new`, the book, watch mode
+- [docs/orders.md](docs/orders.md) - work orders, `zot new`, the book, standing orders, watch mode
 - [docs/providers.md](docs/providers.md) - providers, credentials, gateways, custom endpoints
 - [docs/configuration.md](docs/configuration.md) - config file, flags, controls, sessions, `AGENTS.md` & skills
 - [docs/how-it-works.md](docs/how-it-works.md) - the harness, what sits under it, sub-agents
@@ -88,6 +88,7 @@ session ships to a public dataset.
 | --- | --- | --- | --- |
 | [Arcade](https://openzot.github.io/arcade/) | One brand-new browser game per shift, playtested and published | [openzot/arcade](https://github.com/openzot/arcade) | [openzot/arcade](https://huggingface.co/datasets/openzot/arcade) |
 | [Machinery](https://openzot.github.io/machinery/) | One working control panel per shift - a live simulation, faults, and its operating manual | [openzot/machinery](https://github.com/openzot/machinery) | [openzot/machinery](https://huggingface.co/datasets/openzot/machinery) |
+| [Whetstone](https://openzot.github.io/whetstone/) | One game honed toward perfection - each shift improves one facet and ships the next playable version | [openzot/whetstone](https://github.com/openzot/whetstone) | [openzot/whetstone](https://huggingface.co/datasets/openzot/whetstone) |
 
 ## Ecosystem
 

--- a/docs/orders.md
+++ b/docs/orders.md
@@ -53,6 +53,44 @@ A project's orders and the receipts of what has been run from them live
 together under `.zot/`, and both halves point wherever you like - see
 [the book](configuration.md#the-book).
 
+## Orders persist
+
+Orders are files, and files belong in repositories. Committing an order makes
+it part of the project: reviewable in a pull request, versioned with the code
+it asks for, and there for whoever - or whatever - runs it next. The ledger
+decides what happens then, and there are two honest ways to set it up:
+
+- **A committed one-shot order** is a to-do with a receipt. Commit `.zot/`
+  (orders and records together) and a satisfied order is skipped by every
+  future `zot`, on every machine - "already done" travels with the repository.
+  Edit the order and its changed content re-queues, like everything in the
+  book.
+- **A standing order** is the opposite: one committed file meant to run
+  forever, each run producing new work from the same words. Doneness is the
+  one thing it must never acquire, so run it with `--rerun` (which ignores
+  settled records) and keep `.zot/` out of the repository (`.gitignore` it) so
+  no receipt can retire it. What carries from run to run is not the ledger but
+  whatever the order tells the agent to read first - a catalogue, a log of
+  previous passes - which is how each run knows what the last one did.
+
+The [factories](https://github.com/openzot) are standing orders in public:
+[the arcade](https://github.com/openzot/arcade)'s `orders/new-game.yaml` makes
+a new browser game every shift, [the
+machinery](https://github.com/openzot/machinery)'s builds a new machine, and
+[the whetstone](https://github.com/openzot/whetstone)'s hones the same game
+version after version. Each is a small YAML file committed at the root of its
+repository, handed to zot every 30 minutes by a cron with `rerun` set - the
+whole factory is the order, the conventions file beside it, and a gate script.
+
+Persisted orders run together like any others: `zot orders/*.yaml` runs
+exactly those, in filename order, and a bare `zot` runs the project's whole
+book - so a repository can carry several standing orders, or a standing order
+alongside one-shot work, and one invocation carries out whatever is
+outstanding (with `--rerun` making the standing ones run regardless). Running
+zot from CI works the same way; the
+[openzot/actions](https://github.com/openzot/actions) action wraps exactly
+this, with `orders:` and `rerun:` inputs.
+
 ## Orders stream
 
 `zot --watch` keeps zot up and runs every `*.yaml` order that lands in the


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `repos/zot/tool` on branch `next` → `main`.